### PR TITLE
Restrict block size to 128 bits (16 bytes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 - No dependencies (required BouncyCastle classes are repackaged)
 - Passes official RFC 5297 test vectors
 - Constant time authentication
-- Defaults on AES, but supports any block cipher
+- Defaults on AES, but supports any block cipher with a 128-bit block size.
+- Supports any key sizes that the block cipher supports (e.g. 128/192/256-bit keys for AES)
 - Thread-safe
 
 ## Usage

--- a/src/main/java/org/cryptomator/siv/SivMode.java
+++ b/src/main/java/org/cryptomator/siv/SivMode.java
@@ -55,9 +55,15 @@ public final class SivMode {
 	/**
 	 * Creates an instance using a specific BlockCipher. If you want to use AES, just use the default constructor.
 	 * 
-	 * @param cipherFactory A factory method creating a BlockCipher.
+	 * @param cipherFactory A factory method creating a BlockCipher. Must use a block size of 128 bits (16 bytes).
 	 */
 	public SivMode(BlockCipherFactory cipherFactory) {
+		// Try using cipherFactory to check that the block size is valid.
+		// We assume here that the block size will not vary across calls to .create().
+		if (cipherFactory.create().getBlockSize() != 16) {
+			throw new IllegalArgumentException("cipherFactory must create BlockCipher objects with a 16-byte block size");
+		}
+
 		this.cipherFactory = cipherFactory;
 	}
 

--- a/src/test/java/org/cryptomator/siv/SivModeTest.java
+++ b/src/test/java/org/cryptomator/siv/SivModeTest.java
@@ -16,6 +16,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.bouncycastle.crypto.BlockCipher;
+import org.bouncycastle.crypto.engines.DESEngine;
 import org.cryptomator.siv.SivMode.BlockCipherFactory;
 import org.junit.Assert;
 import org.junit.Test;
@@ -60,6 +61,20 @@ public class SivModeTest {
 		});
 
 		sivMode.encrypt(ctrKey, macKey, new byte[10]);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidCipher() {
+		final byte[] dummyKey = new byte[16];
+		final SecretKey ctrKey = new SecretKeySpec(dummyKey, "AES");
+		final SecretKey macKey = new SecretKeySpec(dummyKey, "AES");
+		final SivMode sivMode = new SivMode(new BlockCipherFactory() {
+
+			@Override
+			public BlockCipher create() {
+				return new DESEngine(); // wrong block size
+			}
+		});
 	}
 
 	@Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Make it clear to library users that this implementation only supports block ciphers with a block size of 128 bits