### PR TITLE
Throw exception if additionalData is too long

### DIFF
--- a/src/main/java/org/cryptomator/siv/SivMode.java
+++ b/src/main/java/org/cryptomator/siv/SivMode.java
@@ -221,6 +221,12 @@ public final class SivMode {
 
 	// Visible for testing, throws IllegalArgumentException if key is not accepted by CMac#init(CipherParameters)
 	byte[] s2v(byte[] macKey, byte[] plaintext, byte[]... additionalData) {
+		// Maximum permitted AD length is the block size in bits - 2
+		if (additionalData.length > 126) {
+			// SIV mode cannot be used safely with this many AD fields
+			throw new IllegalArgumentException("too many Additional Data fields");
+		}
+
 		final CipherParameters params = new KeyParameter(macKey);
 		final BlockCipher cipher = cipherFactory.create();
 		final CMac mac = new CMac(cipher);

--- a/src/test/java/org/cryptomator/siv/SivModeTest.java
+++ b/src/test/java/org/cryptomator/siv/SivModeTest.java
@@ -91,6 +91,24 @@ public class SivModeTest {
 		new SivMode().decrypt(ctrKey, macKey, new byte[10]);
 	}
 
+	@Test(expected = IllegalArgumentException.class)
+	public void testEncryptAdditionalDataLimit() {
+		final byte[] ctrKey = new byte[16];
+		final byte[] macKey = new byte[16];
+		final byte[] plaintext = new byte[30];
+
+		new SivMode().encrypt(ctrKey, macKey, plaintext, new byte[127][0]);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testDecryptAdditionalDataLimit() throws AEADBadTagException, IllegalBlockSizeException {
+		final byte[] ctrKey = new byte[16];
+		final byte[] macKey = new byte[16];
+		final byte[] plaintext = new byte[80];
+
+		new SivMode().decrypt(ctrKey, macKey, plaintext, new byte[127][0]);
+	}
+
 	@Test
 	public void testS2v() {
 		final byte[] macKey = {(byte) 0xff, (byte) 0xfe, (byte) 0xfd, (byte) 0xfc, //


### PR DESCRIPTION
SIV mode is unsafe if too many additional associated data fields are permitted (see RFC5297 Section 7).