### PR TITLE
Improve dbl's resistance to side channel attacks

### DIFF
--- a/src/main/java/org/cryptomator/siv/SivMode.java
+++ b/src/main/java/org/cryptomator/siv/SivMode.java
@@ -277,7 +277,8 @@ public final class SivMode {
 		/*
 		 * NOTE: This construction is an attempt at a constant-time implementation.
 		 */
-		ret[in.length - 1] ^= (xor >>> ((1 - carry) << 3));
+		int mask = (-carry) & 0xff;
+		ret[in.length - 1] ^= xor & mask;
 
 		return ret;
 	}


### PR DESCRIPTION
A mask-based approach is constant-time on more CPUs.

The bit shifting approach tries to hide the value of `carry` by
replacing an if statement with a bit shift. The shift distance of the bit
shift is based on whether `carry` is zero or one. This is constant time
with the assumption that the shift distance has no effect on
performance.

On CPUs with a barrel shifter (i.e. most modern x86 processors), this is
a safe assumption. However, on other processors, the computation time may vary
based on the shift distance, which can expose information about the
value of `carry`.

Note: Bouncy Castle adopted this technique as well in https://github.com/bcgit/bc-java/commit/bdba0816e7cc826f78b3e1e32d552410ced5c62b