### PR TITLE
Allow for providing a JCE provider in JceAesBlockCipher

### DIFF
--- a/src/main/java/org/cryptomator/siv/SivMode.java
+++ b/src/main/java/org/cryptomator/siv/SivMode.java
@@ -9,6 +9,7 @@ package org.cryptomator.siv;
  ******************************************************************************/
 
 import java.nio.ByteBuffer;
+import java.security.Provider;
 import java.util.Arrays;
 
 import javax.crypto.IllegalBlockSizeException;
@@ -40,11 +41,24 @@ public final class SivMode {
 	 * @see #SivMode(BlockCipherFactory)
 	 */
 	public SivMode() {
+		this((Provider) null);
+	}
+
+	/**
+	 * Creates an AES-SIV instance using a custom JCE's security provider<br>
+	 *
+	 * For embedded systems, you might want to consider using {@link #SivMode(BlockCipherFactory)} with {@link AESLightEngine} instead.
+	 *
+	 * @param jceSecurityProvider to use to create the internal {@link javax.crypto.Cipher} instance
+	 *
+	 * @see #SivMode(BlockCipherFactory)
+	 */
+	public SivMode(final Provider jceSecurityProvider) {
 		this(new BlockCipherFactory() {
 
 			@Override
 			public BlockCipher create() {
-				return new JceAesBlockCipher();
+				return new JceAesBlockCipher(jceSecurityProvider);
 			}
 
 		});

--- a/src/test/java/org/cryptomator/siv/SivModeTest.java
+++ b/src/test/java/org/cryptomator/siv/SivModeTest.java
@@ -10,6 +10,8 @@ package org.cryptomator.siv;
 
 import java.io.IOException;
 import java.security.InvalidKeyException;
+import java.security.Provider;
+import java.security.Security;
 
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.SecretKey;
@@ -141,6 +143,9 @@ public class SivModeTest {
 
 		final byte[] result = new SivMode().generateKeyStream(ctrKey, ctr, 1);
 		Assert.assertArrayEquals(expected, result);
+
+		final byte[] resultProvider = new SivMode(getSunJceProvider()).generateKeyStream(ctrKey, ctr, 1);
+		Assert.assertArrayEquals(expected, resultProvider);
 	}
 
 	// CTR-AES https://tools.ietf.org/html/rfc5297#appendix-A.2
@@ -199,6 +204,9 @@ public class SivModeTest {
 
 		final byte[] result = new SivMode().s2v(macKey, plaintext, ad);
 		Assert.assertArrayEquals(expected, result);
+
+		final byte[] resultProvider = new SivMode(getSunJceProvider()).s2v(macKey, plaintext, ad);
+		Assert.assertArrayEquals(expected, resultProvider);
 	}
 
 	@Test
@@ -584,4 +592,9 @@ public class SivModeTest {
 		}
 	}
 
+	private Provider getSunJceProvider() {
+		Provider provider = Security.getProvider("SunJCE");
+		Assert.assertNotNull(provider);
+		return provider;
+	}
 }


### PR DESCRIPTION
This refactors JceAesBlockCipher and SivMode to accept, next to
the no-arg const, a single arg constructor accepting a jce provider, but
still using the default AES implementation.

Bonus: Visibility of JceAesBlockCipher const fixed to reflect the class
 visibility and typo fixed in JceAesBlockCipherTest

refs #10