### PR TITLE
Update Bouncycastle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 		<project.build.outputTimestamp>2023-10-06T15:40:39Z</project.build.outputTimestamp>
 
 		<!-- dependencies -->
-		<bouncycastle.version>1.70</bouncycastle.version>
+		<bouncycastle.version>1.78</bouncycastle.version>
 
 		<!-- test dependencies -->
 		<junit.version>5.10.2</junit.version>
@@ -54,7 +54,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk15on</artifactId>
+			<artifactId>bcprov-jdk18on</artifactId>
 			<version>${bouncycastle.version}</version>
 			<!-- see maven-shade-plugin; we don't want this as a transitive dependency in other projects -->
 			<optional>true</optional>


### PR DESCRIPTION
Change bouncycastle dependency from bcprov-jdk15on:1.70 to bcprov-jdk18on:1.78

This project already requires JDK 1.8, hence there are no compatibility issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Bouncy Castle library version to enhance security and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->