### PR TITLE
fix bouncycastle artifacts are not included in build jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
 							<createSourcesJar>false</createSourcesJar>
 							<artifactSet>
 								<includes>
-									<include>org.bouncycastle:bcprov-jdk15on</include>
+									<include>org.bouncycastle:bcprov-jdk18on</include>
 								</includes>
 							</artifactSet>
 							<relocations>
@@ -235,7 +235,7 @@
 							</relocations>
 							<filters>
 								<filter>
-									<artifact>org.bouncycastle:bcprov-jdk15on</artifact>
+									<artifact>org.bouncycastle:bcprov-jdk18on</artifact>
 									<excludes>
 										<exclude>META-INF/**</exclude>
 									</excludes>


### PR DESCRIPTION
Fixes #47.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the artifact version in the project configuration to enhance compatibility and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->