### PR TITLE
Update org.owasp:dependency-check-maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 		<guava.version>33.2.1-jre</guava.version>
 
 		<!-- maven plugins -->
-		<dependency-check.version>9.2.0</dependency-check.version>
+		<dependency-check.version>10.0.2</dependency-check.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
from 9.2.0 to 10.0.2.

Required due to https://github.com/jeremylong/DependencyCheck/issues/6746 (and trailing issues).