### PR TITLE
[skip ci] bump dependency-check-workflow to version 3

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -5,16 +5,17 @@ on:
   push:
     branches:
       - 'release/**'
+      - 'hotfix/**'
   workflow_dispatch:
 
 
 jobs:
   check-dependencies:
-    uses: skymatic/workflows/.github/workflows/run-dependency-check.yml@v1
+    uses: skymatic/workflows/.github/workflows/run-dependency-check.yml@v3
     with:
-      runner-os: 'ubuntu-latest'
-      java-distribution: 'zulu'
       java-version: 21
     secrets:
       nvd-api-key: ${{ secrets.NVD_API_KEY }}
+      ossindex-username: ${{ secrets.OSSINDEX_USERNAME }}
+      ossindex-token: ${{ secrets.OSSINDEX_API_TOKEN }}
       slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This PR increases the robustness of the dependency-check workflow.

With v3 of the reusable workflow, we don't have to maintain the dependency-check version anymore. Also, security is increased by changing the parameters from the actual command line to only path to pom and suppression.xml.