### PR TITLE
[blocked] Build with Maven 4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar
       - name: Ensure to use tagged version
         if: startsWith(github.ref, 'refs/tags/')
-        run: ./mvnw versions:set --file ./pom.xml -DnewVersion=${GITHUB_REF##*/}
+        run: echo "-Drevision=${GITHUB_REF##*/}" >> .mvn/maven.config
       - name: Build and Test
         run: >
           ./mvnw -B verify --no-transfer-progress
@@ -86,11 +86,11 @@ jobs:
           server-password: MAVEN_CENTRAL_PASSWORD
       - name: Ensure to use tagged version
         if: startsWith(github.ref, 'refs/tags/')
-        run: ./mvnw versions:set --file ./pom.xml -DnewVersion=${GITHUB_REF##*/}
+        run: echo "-Drevision=${GITHUB_REF##*/}" >> .mvn/maven.config
       - name: Verify project version is -SNAPSHOT
         if: startsWith(github.ref, 'refs/tags/') == false
         run: |
-          PROJECT_VERSION=$(./mvnw help:evaluate "-Dexpression=project.version" -q -DforceStdout)
+          PROJECT_VERSION=$(./mvnw help:evaluate "-Dexpression=revision" -q -DforceStdout)
           test "${PROJECT_VERSION: -9}" = "-SNAPSHOT"
       - name: Deploy to Maven Central
         run: ./mvnw deploy -B -DskipTests -Psign,deploy-central --no-transfer-progress
@@ -119,11 +119,11 @@ jobs:
           cache: 'maven'
       - name: Ensure to use tagged version
         if: startsWith(github.ref, 'refs/tags/')
-        run: ./mvnw versions:set --file ./pom.xml -DnewVersion=${GITHUB_REF##*/}
+        run: echo "-Drevision=${GITHUB_REF##*/}" >> .mvn/maven.config
       - name: Verify project version is -SNAPSHOT
         if: startsWith(github.ref, 'refs/tags/') == false
         run: |
-          PROJECT_VERSION=$(./mvnw help:evaluate "-Dexpression=project.version" -q -DforceStdout)
+          PROJECT_VERSION=$(./mvnw help:evaluate "-Dexpression=revision" -q -DforceStdout)
           test "${PROJECT_VERSION: -9}" = "-SNAPSHOT"
       - name: Deploy to GitHub Packages
         run: ./mvnw deploy -B -DskipTests -Psign,deploy-github --no-transfer-progress

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,3 @@
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/4.0.0-rc-5/apache-maven-4.0.0-rc-5-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 http://maven.apache.org/xsd/maven-4.1.0.xsd">
 	<groupId>org.cryptomator</groupId>
 	<artifactId>siv-mode</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>${revision}</version>
 
 	<name>SIV Mode</name>
 	<description>RFC 5297 SIV mode: deterministic authenticated encryption</description>
@@ -36,7 +35,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.build.outputTimestamp>2025-03-14T12:02:43Z</project.build.outputTimestamp>
+		<revision>2.0.0-SNAPSHOT</revision>
 
 		<!-- test dependencies -->
 		<junit.version>6.0.1</junit.version>


### PR DESCRIPTION
* Update mvnw to `4.0.0-rc-5`
* Update pom.xml to model version 4.1.0
* Use `-Drevision` to control project version during CI builds

> [!Warning]
> `central-publishing-maven-plugin` doesn't support Maven 4 yet. According to Sonatype this is a known issue and they have it on their roadmap. Until then, we can not start publishing with Maven 4.